### PR TITLE
Updated Feather icons URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ hide-header: true
 				</div>
 				<div class="feature-description">
 					<h3 class="feature-name">Simply, beautiful, open source icons</h3>
-					<p>Tabler is build with the newest version of <a href="https://feather.netlify.com/">Feather icons</a> made by <a href="https://twitter.com/colebemis">Cole Bemis</a>. Each&nbsp;icon is designed with an emphasis on simplicity, consistency and readability.</p>
+					<p>Tabler is build with the newest version of <a href="https://feathericons.com">Feather icons</a> made by <a href="https://twitter.com/colebemis">Cole Bemis</a>. Each&nbsp;icon is designed with an emphasis on simplicity, consistency and readability.</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
In the Feather Icons [repo](https://github.com/feathericons/feather), the URL is https://feathericons.com but on this website, it was a different URL, pointing to the same document.